### PR TITLE
fixing pixel-c crashes....wrap content causing issues for book list -- Issue#5

### DIFF
--- a/app/src/main/res/layout/list_item_book.xml
+++ b/app/src/main/res/layout/list_item_book.xml
@@ -10,7 +10,7 @@
     <android.support.v7.widget.CardView
         android:id="@+id/card_view"
         android:layout_width="@dimen/book_column_width"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/book_column_height"
         android:layout_gravity="center"
         android:layout_margin="4dp"
 

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="book_column_width">192dp</dimen>
+    <dimen name="book_column_height">250dp</dimen>
     <dimen name="book_column_width_padding">208dp</dimen>
     <dimen name="text_size_page">28sp</dimen>
     <dimen name="fab_button_size">62dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,6 +4,7 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="book_column_width">144dp</dimen>
+    <dimen name="book_column_height">205dp</dimen>
     <dimen name="book_column_width_padding">160dp</dimen>
     <dimen name="book_list_padding">8dp</dimen>
     <dimen name="text_size_page">14sp</dimen>


### PR DESCRIPTION
wrap_content in the cardView height appears to lead to a situation where a negative height value is being handed to OpenGLRenderer in certain orientations (which is probably internally because it is trying to determine the outside objects height before all of the inside ones are done.)  This is probably a Lollipop issue only,  but the fix is to go to fixed heights and then everything works.